### PR TITLE
Support lowering minSDK upto 16 for Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 16
     }
 
     lintOptions {
@@ -40,5 +40,5 @@ android {
 
 dependencies {
     //implementation 'androidx.core:core:1.3.1'
-    implementation "androidx.media2:media2-session:1.0.3"
+    implementation "androidx.media2:media2-session:1.1.0-alpha01"
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.ryanheise.audio_session_example"
-        minSdkVersion 19
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Used **v1.1.0-alpha01** of `androidx.media2.session`, as it supports lowering minSDK upto 16.