### PR TITLE
Add onAudioFocusGained to methodCallHandler on iOS.

### DIFF
--- a/ios/Classes/DarwinAudioSession.m
+++ b/ios/Classes/DarwinAudioSession.m
@@ -396,9 +396,9 @@ static NSMutableArray<DarwinAudioSession *> *sessions = nil;
         case AVAudioSessionInterruptionTypeEnded:
         {
             if ([(NSNumber*)[notification.userInfo valueForKey:AVAudioSessionInterruptionOptionKey] intValue] == AVAudioSessionInterruptionOptionShouldResume) {
-                [self invokeMethod:@"onAudioFocusGained" arguments:@[@(1), @(1)]];
+                [self invokeMethod:@"onInterruptionEvent" arguments:@[@(1), @(1)]];
             } else {
-                [self invokeMethod:@"onAudioFocusGained" arguments:@[@(1), @(0)]];
+                [self invokeMethod:@"onInterruptionEvent" arguments:@[@(1), @(0)]];
             }
             break;
         }

--- a/lib/src/darwin.dart
+++ b/lib/src/darwin.dart
@@ -31,13 +31,6 @@ class AVAudioSession {
             options: AVAudioSessionInterruptionOptions(args[1]),
           ));
           break;
-        case 'onAudioFocusGained':
-          _interruptionNotificationSubject
-              .add(AVAudioSessionInterruptionNotification(
-            type: AVAudioSessionInterruptionType.values[args[0]],
-            options: AVAudioSessionInterruptionOptions(args[1]),
-          ));
-          break;
       }
     });
   }

--- a/lib/src/darwin.dart
+++ b/lib/src/darwin.dart
@@ -31,6 +31,13 @@ class AVAudioSession {
             options: AVAudioSessionInterruptionOptions(args[1]),
           ));
           break;
+        case 'onAudioFocusGained':
+          _interruptionNotificationSubject
+              .add(AVAudioSessionInterruptionNotification(
+            type: AVAudioSessionInterruptionType.values[args[0]],
+            options: AVAudioSessionInterruptionOptions(args[1]),
+          ));
+          break;
       }
     });
   }


### PR DESCRIPTION
I saw that the audioInterrupt AVAudioSessionInterruptionTypeEnded was already implemented in the DarwinAudioSession.m but was missing the corresponding methodHandler.

The implementation is just a copy paste of the onInterruptionEvent handler and works as intended.