### PR TITLE
RouteChange, MediaServiceLost/Reset and SilenceSecondaryAudioHint for iOS

### DIFF
--- a/ios/Classes/DarwinAudioSession.m
+++ b/ios/Classes/DarwinAudioSession.m
@@ -26,6 +26,10 @@ static NSMutableArray<DarwinAudioSession *> *sessions = nil;
     }];
     [AVAudioSession sharedInstance];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioInterrupt:) name:AVAudioSessionInterruptionNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(routeChange:) name:AVAudioSessionRouteChangeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(silenceSecondaryAudio:) name:AVAudioSessionSilenceSecondaryAudioHintNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(mediaServicesLost:) name:AVAudioSessionMediaServicesWereLostNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(mediaServicesReset:) name:AVAudioSessionMediaServicesWereResetNotification object:nil];
     return self;
 }
 
@@ -405,6 +409,28 @@ static NSMutableArray<DarwinAudioSession *> *sessions = nil;
         default:
             break;
     }
+}
+
+- (void) routeChange:(NSNotification*)notification {
+    NSNumber *routeChangeReasonType = (NSNumber*)[notification.userInfo valueForKey:AVAudioSessionRouteChangeReasonKey];
+    NSLog(@"routeChange detected");
+    [self invokeMethod:@"onRouteChange" arguments:@[@([routeChangeReasonType integerValue])]];
+}
+
+- (void) silenceSecondaryAudio:(NSNotification*)notification {
+    NSNumber *silenceSecondaryType = (NSNumber*)[notification.userInfo valueForKey:AVAudioSessionSilenceSecondaryAudioHintTypeKey];
+    NSLog(@"silenceSecondaryAudioHint detected");
+    [self invokeMethod:@"onRouteChange" arguments:@[@([silenceSecondaryType integerValue])]];
+}
+
+- (void) mediaServicesLost:(NSNotification*)notification {
+    NSLog(@"mediaServicesLost detected");
+    [self invokeMethod:@"onMediaServicesWereLost" arguments:nil];
+}
+
+- (void) mediaServicesReset:(NSNotification*)notification {
+    NSLog(@"mediaServicesReset detected");
+    [self invokeMethod:@"onMediaServicesWereReset" arguments:nil];
 }
 
 - (void) invokeMethod:(NSString *)method arguments:(id _Nullable)arguments {

--- a/ios/Classes/DarwinAudioSession.m
+++ b/ios/Classes/DarwinAudioSession.m
@@ -420,7 +420,7 @@ static NSMutableArray<DarwinAudioSession *> *sessions = nil;
 - (void) silenceSecondaryAudio:(NSNotification*)notification {
     NSNumber *silenceSecondaryType = (NSNumber*)[notification.userInfo valueForKey:AVAudioSessionSilenceSecondaryAudioHintTypeKey];
     NSLog(@"silenceSecondaryAudioHint detected");
-    [self invokeMethod:@"onRouteChange" arguments:@[@([silenceSecondaryType integerValue])]];
+    [self invokeMethod:@"onSilenceSecondaryAudioHint" arguments:@[@([silenceSecondaryType integerValue])]];
 }
 
 - (void) mediaServicesLost:(NSNotification*)notification {

--- a/ios/Classes/DarwinAudioSession.m
+++ b/ios/Classes/DarwinAudioSession.m
@@ -412,9 +412,18 @@ static NSMutableArray<DarwinAudioSession *> *sessions = nil;
 }
 
 - (void) routeChange:(NSNotification*)notification {
-    NSNumber *routeChangeReasonType = (NSNumber*)[notification.userInfo valueForKey:AVAudioSessionRouteChangeReasonKey];
     NSLog(@"routeChange detected");
-    [self invokeMethod:@"onRouteChange" arguments:@[@([routeChangeReasonType integerValue])]];
+    NSNumber *routeChangeReasonType = (NSNumber*)[notification.userInfo valueForKey:AVAudioSessionRouteChangeReasonKey];
+    AVAudioSessionRouteDescription *previousRouteDescription = [notification.userInfo valueForKey:AVAudioSessionRouteChangePreviousRouteKey];
+    NSNumber *shouldInterrupt = @(0);
+    if (previousRouteDescription) {
+        for (AVAudioSessionPortDescription *output in previousRouteDescription.outputs) {
+            if ([[output portType] isEqualToString:AVAudioSessionPortHeadphones] || [[output portType] isEqualToString:AVAudioSessionPortBluetoothA2DP]) {
+              shouldInterrupt = @(1);
+          }
+        }
+    }
+    [self invokeMethod:@"onRouteChange" arguments:@[@([routeChangeReasonType integerValue]), shouldInterrupt]];
 }
 
 - (void) silenceSecondaryAudio:(NSNotification*)notification {

--- a/ios/Classes/DarwinAudioSession.m
+++ b/ios/Classes/DarwinAudioSession.m
@@ -412,18 +412,9 @@ static NSMutableArray<DarwinAudioSession *> *sessions = nil;
 }
 
 - (void) routeChange:(NSNotification*)notification {
-    NSLog(@"routeChange detected");
     NSNumber *routeChangeReasonType = (NSNumber*)[notification.userInfo valueForKey:AVAudioSessionRouteChangeReasonKey];
-    AVAudioSessionRouteDescription *previousRouteDescription = [notification.userInfo valueForKey:AVAudioSessionRouteChangePreviousRouteKey];
-    NSNumber *shouldInterrupt = @(0);
-    if (previousRouteDescription) {
-        for (AVAudioSessionPortDescription *output in previousRouteDescription.outputs) {
-            if ([[output portType] isEqualToString:AVAudioSessionPortHeadphones] || [[output portType] isEqualToString:AVAudioSessionPortBluetoothA2DP]) {
-              shouldInterrupt = @(1);
-          }
-        }
-    }
-    [self invokeMethod:@"onRouteChange" arguments:@[@([routeChangeReasonType integerValue]), shouldInterrupt]];
+    NSLog(@"routeChange detected");
+    [self invokeMethod:@"onRouteChange" arguments:@[@([routeChangeReasonType integerValue])]];
 }
 
 - (void) silenceSecondaryAudio:(NSNotification*)notification {

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -40,6 +40,12 @@ class AudioSession {
   AudioSessionConfiguration _configuration;
   final _configurationSubject = BehaviorSubject<AudioSessionConfiguration>();
   final _interruptionEventSubject = PublishSubject<AudioInterruptionEvent>();
+  final _routeChangeReasonSubject =
+      PublishSubject<AVAudioSessionRouteChangeReason>();
+  final _silenceSecondaryAudioHintSubject =
+      PublishSubject<AVAudioSessionSilenceSecondaryAudioHintType>();
+  final _mediaServicesWereLostSubject = PublishSubject<void>();
+  final _mediaServicesWereResetSubject = PublishSubject<void>();
   final _becomingNoisyEventSubject = PublishSubject<void>();
 
   AudioSession._() {
@@ -59,6 +65,12 @@ class AudioSession {
           break;
       }
     });
+    _avAudioSession?.silenceSecondaryAudioHintStream
+        ?.listen((event) => _silenceSecondaryAudioHintSubject.add(event));
+    _avAudioSession?.mediaServicesWereLostStream
+        ?.listen((event) => _mediaServicesWereLostSubject.add(event));
+    _avAudioSession?.mediaServicesWereResetStream
+        ?.listen((event) => _mediaServicesWereResetSubject.add(event));
     _androidAudioManager?.becomingNoisyEventStream
         ?.listen((event) => _becomingNoisyEventSubject.add(event));
     _channel.setMethodCallHandler((MethodCall call) async {
@@ -98,6 +110,25 @@ class AudioSession {
   /// unplugging the headphones).
   Stream<void> get becomingNoisyEventStream =>
       _becomingNoisyEventSubject.stream;
+
+  /// A stream of events that occur when route change is detected (e.g. due to
+  /// unplugging the headphones or new devices detected).
+  Stream<AVAudioSessionRouteChangeReason> get routeChangeReasonStream =>
+      _routeChangeReasonSubject.stream;
+
+  /// A stream of events that occur when another application’s primary audio
+  /// has started and indicate whether optional secondary audio muting should
+  /// begin or end.
+  Stream<AVAudioSessionSilenceSecondaryAudioHintType>
+      get silenceSecondaryAudioHintStream => _silenceSecondaryAudioHintSubject.stream;
+
+  /// A stream of events when occur when a media server restarts.
+  Stream<void> get mediaServicesWereResetStream =>
+      _mediaServicesWereResetSubject.stream;
+
+  /// A stream of events when occur when a media server is lost.
+  Stream<void> get mediaServicesWereLostStream =>
+      _mediaServicesWereLostSubject.stream;
 
   /// Configures the audio session. It is useful to call this method during
   /// your app's initialisation before you start playing or recording any

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -40,12 +40,6 @@ class AudioSession {
   AudioSessionConfiguration _configuration;
   final _configurationSubject = BehaviorSubject<AudioSessionConfiguration>();
   final _interruptionEventSubject = PublishSubject<AudioInterruptionEvent>();
-  final _routeChangeReasonSubject =
-      PublishSubject<AVAudioSessionRouteChangeReason>();
-  final _silenceSecondaryAudioHintSubject =
-      PublishSubject<AVAudioSessionSilenceSecondaryAudioHintType>();
-  final _mediaServicesWereLostSubject = PublishSubject<void>();
-  final _mediaServicesWereResetSubject = PublishSubject<void>();
   final _becomingNoisyEventSubject = PublishSubject<void>();
 
   AudioSession._() {
@@ -65,12 +59,8 @@ class AudioSession {
           break;
       }
     });
-    _avAudioSession?.silenceSecondaryAudioHintStream
-        ?.listen((event) => _silenceSecondaryAudioHintSubject.add(event));
-    _avAudioSession?.mediaServicesWereLostStream
-        ?.listen((event) => _mediaServicesWereLostSubject.add(event));
-    _avAudioSession?.mediaServicesWereResetStream
-        ?.listen((event) => _mediaServicesWereResetSubject.add(event));
+    _avAudioSession?.becomingNoisyEventStream
+        ?.listen((event) => _becomingNoisyEventSubject.add(event));
     _androidAudioManager?.becomingNoisyEventStream
         ?.listen((event) => _becomingNoisyEventSubject.add(event));
     _channel.setMethodCallHandler((MethodCall call) async {
@@ -110,25 +100,6 @@ class AudioSession {
   /// unplugging the headphones).
   Stream<void> get becomingNoisyEventStream =>
       _becomingNoisyEventSubject.stream;
-
-  /// A stream of events that occur when route change is detected (e.g. due to
-  /// unplugging the headphones or new devices detected).
-  Stream<AVAudioSessionRouteChangeReason> get routeChangeReasonStream =>
-      _routeChangeReasonSubject.stream;
-
-  /// A stream of events that occur when another application’s primary audio
-  /// has started and indicate whether optional secondary audio muting should
-  /// begin or end.
-  Stream<AVAudioSessionSilenceSecondaryAudioHintType>
-      get silenceSecondaryAudioHintStream => _silenceSecondaryAudioHintSubject.stream;
-
-  /// A stream of events when occur when a media server restarts.
-  Stream<void> get mediaServicesWereResetStream =>
-      _mediaServicesWereResetSubject.stream;
-
-  /// A stream of events when occur when a media server is lost.
-  Stream<void> get mediaServicesWereLostStream =>
-      _mediaServicesWereLostSubject.stream;
 
   /// Configures the audio session. It is useful to call this method during
   /// your app's initialisation before you start playing or recording any

--- a/lib/src/darwin.dart
+++ b/lib/src/darwin.dart
@@ -11,7 +11,7 @@ class AVAudioSession {
   final _interruptionNotificationSubject =
       PublishSubject<AVAudioSessionInterruptionNotification>();
   final _becomingNoisyEventSubject = PublishSubject<void>();
-  final _routeChangeSubject = PublishSubject<AVAudioSessionRouteChangeReason>();
+  final _routeChangeSubject = PublishSubject<AVAudioSessionRouteChange>();
   final _silenceSecondaryAudioHintSubject =
       PublishSubject<AVAudioSessionSilenceSecondaryAudioHintType>();
   final _mediaServicesWereLostSubject = PublishSubject<void>();
@@ -34,9 +34,11 @@ class AVAudioSession {
           ));
           break;
         case 'onRouteChange':
-          AVAudioSessionRouteChangeReason reason = AVAudioSessionRouteChangeReason.values[args[0]];
-          _routeChangeSubject.add(reason);
-          if (reason == AVAudioSessionRouteChangeReason.oldDeviceUnavailable) {
+          AVAudioSessionRouteChange routeChange = AVAudioSessionRouteChange(
+              reason: AVAudioSessionRouteChangeReason.values[args[0]]);
+          _routeChangeSubject.add(routeChange);
+          if (routeChange.reason ==
+              AVAudioSessionRouteChangeReason.oldDeviceUnavailable) {
             _becomingNoisyEventSubject.add(null);
           }
           break;
@@ -61,7 +63,7 @@ class AVAudioSession {
   Stream<void> get becomingNoisyEventStream =>
       _becomingNoisyEventSubject.stream;
 
-  Stream<AVAudioSessionRouteChangeReason> get routeChangeReasonStream =>
+  Stream<AVAudioSessionRouteChange> get routeChangeStream =>
       _routeChangeSubject.stream;
 
   Stream<AVAudioSessionSilenceSecondaryAudioHintType>
@@ -430,6 +432,13 @@ class AVAudioSessionInterruptionOptions {
       option is AVAudioSessionInterruptionOptions && value == option.value;
 
   int get hashCode => value.hashCode;
+}
+
+class AVAudioSessionRouteChange {
+  final AVAudioSessionRouteChangeReason reason;
+  // add everything else later
+
+  AVAudioSessionRouteChange({@required this.reason});
 }
 
 /// The route change reasons for [AVAudioSession].

--- a/lib/src/darwin.dart
+++ b/lib/src/darwin.dart
@@ -454,7 +454,7 @@ enum AVAudioSessionRouteChangeReason {
 }
 
 /// The interruption types for [AVAudioSessionSilenceSecondaryAudioHint].
-enum AVAudioSessionSilenceSecondaryAudioHintType { began, end }
+enum AVAudioSessionSilenceSecondaryAudioHintType { end, begin }
 
 //class AVAudioSessionRouteDescription {
 //  final List<AVAudioSessionPortDescription> inputs;

--- a/lib/src/darwin.dart
+++ b/lib/src/darwin.dart
@@ -9,11 +9,11 @@ class AVAudioSession {
 
   final _interruptionNotificationSubject =
       PublishSubject<AVAudioSessionInterruptionNotification>();
-  //final _routeChangeSubject = PublishSubject<AVAudioSessionRouteChangeReason>();
-  //final _silenceSecondaryAudioHintSubject =
-  //    PublishSubject<AVAudioSessionSilenceSecondaryAudioHintType>();
-  //final _mediaServicesWereLostSubject = PublishSubject<void>();
-  //final _mediaServicesWereResetSubject = PublishSubject<void>();
+  final _routeChangeSubject = PublishSubject<AVAudioSessionRouteChangeReason>();
+  final _silenceSecondaryAudioHintSubject =
+      PublishSubject<AVAudioSessionSilenceSecondaryAudioHintType>();
+  final _mediaServicesWereLostSubject = PublishSubject<void>();
+  final _mediaServicesWereResetSubject = PublishSubject<void>();
 
   factory AVAudioSession() {
     if (_instance == null) _instance = AVAudioSession._();
@@ -31,6 +31,20 @@ class AVAudioSession {
             options: AVAudioSessionInterruptionOptions(args[1]),
           ));
           break;
+        case 'onRouteChange':
+          _routeChangeSubject
+              .add(AVAudioSessionRouteChangeReason.values[args[0]]);
+          break;
+        case 'onSilenceSecondaryAudioHint':
+          _silenceSecondaryAudioHintSubject
+              .add(AVAudioSessionSilenceSecondaryAudioHintType.values[args[0]]);
+          break;
+        case 'onMediaServicesWereLost':
+          _mediaServicesWereLostSubject.add(null);
+          break;
+        case 'onMediaServicesWereReset':
+          _mediaServicesWereResetSubject.add(null);
+          break;
       }
     });
   }
@@ -38,6 +52,19 @@ class AVAudioSession {
   Stream<AVAudioSessionInterruptionNotification>
       get interruptionNotificationStream =>
           _interruptionNotificationSubject.stream;
+
+  Stream<AVAudioSessionRouteChangeReason> get routeChangeReasonStream =>
+      _routeChangeSubject.stream;
+
+  Stream<AVAudioSessionSilenceSecondaryAudioHintType>
+      get silenceSecondaryAudioHintStream =>
+          _silenceSecondaryAudioHintSubject.stream;
+
+  Stream<void> get mediaServicesWereLostStream =>
+      _mediaServicesWereLostSubject.stream;
+
+  Stream<void> get mediaServicesWereResetStream =>
+      _mediaServicesWereResetSubject.stream;
 
   Future<AVAudioSessionCategory> get category async {
     final int index = await _channel.invokeMethod('getCategory');
@@ -246,10 +273,10 @@ class AVAudioSession {
 
   void close() {
     _interruptionNotificationSubject.close();
-    //_routeChangeSubject.close();
-    //_silenceSecondaryAudioHintSubject.close();
-    //_mediaServicesWereLostSubject.close();
-    //_mediaServicesWereResetSubject.close();
+    _routeChangeSubject.close();
+    _silenceSecondaryAudioHintSubject.close();
+    _mediaServicesWereLostSubject.close();
+    _mediaServicesWereResetSubject.close();
   }
 }
 
@@ -404,20 +431,21 @@ class AVAudioSessionInterruptionOptions {
   int get hashCode => value.hashCode;
 }
 
-///// The route change reasons for [AVAudioSession].
-//enum AVAudioSessionRouteChangeReason {
-//  unknown,
-//  newDeviceAvailable,
-//  oldDeviceUnavailable,
-//  categoryChange,
-//  override,
-//  wakeFromSleep,
-//  noSuitableRouteForCategory,
-//  routeConfigurationChange,
-//}
-//
-//enum AVAudioSessionSilenceSecondaryAudioHintType { begin, end }
-//
+/// The route change reasons for [AVAudioSession].
+enum AVAudioSessionRouteChangeReason {
+  unknown,
+  newDeviceAvailable,
+  oldDeviceUnavailable,
+  categoryChange,
+  override,
+  wakeFromSleep,
+  noSuitableRouteForCategory,
+  routeConfigurationChange,
+}
+
+/// The interruption types for [AVAudioSessionSilenceSecondaryAudioHint].
+enum AVAudioSessionSilenceSecondaryAudioHintType { began, end }
+
 //class AVAudioSessionRouteDescription {
 //  final List<AVAudioSessionPortDescription> inputs;
 //  final List<AVAudioSessionPortDescription> outputs;


### PR DESCRIPTION
This is based on the commented out code already in the repository.

I have tested the RouteChangeNotification and MediaServicesWereLost/Reset quite well, but haven't found a way to test the SilenceSecondaryAudioHintNotification.