### PR TITLE
Fix parameter name in example init

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ await session.configure(AudioSessionConfiguration(
   avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.allowBluetooth,
   avAudioSessionMode: AVAudioSessionMode.spokenAudio,
   avAudioSessionRouteSharingPolicy: AVAudioSessionRouteSharingPolicy.defaultPolicy,
-  avSetActiveOptions: AVAudioSessionSetActiveOptions.none,
+  avAudioSessionSetActiveOptions: AVAudioSessionSetActiveOptions.none,
   androidAudioAttributes: const AndroidAudioAttributes(
     contentType: AndroidAudioContentType.speech,
     flags: AndroidAudioFlags.none,


### PR DESCRIPTION
From `avSetActiveOptions` to `avAudioSessionSetActiveOptions`.