### PR TITLE
Fixes Deprecated API Warning (Issue #24)

### DIFF
--- a/android/src/main/java/com/ryanheise/audio_session/AudioSessionPlugin.java
+++ b/android/src/main/java/com/ryanheise/audio_session/AudioSessionPlugin.java
@@ -8,7 +8,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
The deprecated api was in an import that wasn't even used so it was safe to just remove it.