### PR TITLE
Add newDeviceAvailable case for routeChangeStream detection

### DIFF
--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -83,7 +83,9 @@ class AudioSession {
     _avAudioSession?.routeChangeStream
         .where((routeChange) =>
             routeChange.reason ==
-            AVAudioSessionRouteChangeReason.oldDeviceUnavailable)
+                AVAudioSessionRouteChangeReason.oldDeviceUnavailable ||
+            routeChange.reason ==
+                AVAudioSessionRouteChangeReason.newDeviceAvailable)
         .listen((routeChange) async {
       _becomingNoisyEventSubject.add(null);
       final currentRoute = await _avAudioSession!.currentRoute;


### PR DESCRIPTION
When I used this `devicesChangedEventStream` to detect current connected A2DP speakers for iOS device, I found `devicesChangedEventStream` only can be triggered when I disconnected A2DP speaker, not working when I connected new A2DP speaker.

```dart
/// A stream emitting events whenever devices are added or removed to the set
/// of available devices.
Stream<AudioDevicesChangedEvent> get devicesChangedEventStream =>
      _devicesChangedEventSubject.stream;
```

When I went through the code, I found the filter for routeChangeStream only apply on `AVAudioSessionRouteChangeReason.oldDeviceUnavailable`. It means `devicesChangedEventStream` cannot be trigger for `AVAudioSessionRouteChangeReason.newDeviceAvailable`.  So I created this PR to try to solve this problem. Hopefully  it is a valid solution.

Before:
```dart
 _avAudioSession?.routeChangeStream
        .where((routeChange) =>
            routeChange.reason ==
                AVAudioSessionRouteChangeReason.oldDeviceUnavailable)
        .listen((routeChange) async { }
```

After:
```dart
 _avAudioSession?.routeChangeStream
        .where((routeChange) =>
            routeChange.reason ==
                AVAudioSessionRouteChangeReason.oldDeviceUnavailable ||
            routeChange.reason ==
                AVAudioSessionRouteChangeReason.newDeviceAvailable)
        .listen((routeChange) async { }
```