### PR TITLE
Add new communication device methods of Android AudioManager

### DIFF
--- a/android/src/main/java/com/ryanheise/audio_session/AndroidAudioManager.java
+++ b/android/src/main/java/com/ryanheise/audio_session/AndroidAudioManager.java
@@ -109,6 +109,22 @@ public class AndroidAudioManager implements MethodCallHandler {
                 result.success(singleton.isStreamMute((Integer)args.get(0)));
                 break;
             }
+            case "getAvailableCommunicationDevices": {
+                result.success(singleton.getAvailableCommunicationDevices());
+                break;
+            }
+            case "setCommunicationDevice": {
+                result.success(singleton.setCommunicationDevice((Integer)args.get(0)));
+                break;
+            }
+            case "getCommunicationDevice": {
+                result.success(singleton.getCommunicationDevice());
+                break;
+            }
+            case "clearCommunicationDevice": {
+                result.success(singleton.clearCommunicationDevice());
+                break;
+            }
             case "setSpeakerphoneOn": {
                 result.success(singleton.setSpeakerphoneOn((Boolean)args.get(0)));
                 break;
@@ -240,6 +256,7 @@ public class AndroidAudioManager implements MethodCallHandler {
         private Context applicationContext;
         private AudioManager audioManager;
         private Object audioDeviceCallback;
+        private List<AudioDeviceInfo> devices = new ArrayList<AudioDeviceInfo>();
 
         private static List<?> encodeAudioDevices(AudioDeviceInfo[] devices) {
             ArrayList<Map<String, Object>> result = new ArrayList<>();
@@ -396,6 +413,29 @@ public class AndroidAudioManager implements MethodCallHandler {
         private Object isStreamMute(int streamType) {
             requireApi(23);
             return audioManager.isStreamMute(streamType);
+        }
+        private List<AudioDeviceInfo> getAvailableCommunicationDevices() {
+            requireApi(31);
+            devices = audioManager.getAvailableCommunicationDevices();
+            return devices;
+        }
+        private boolean setCommunicationDevice(Integer deviceId) {
+            requireApi(31);
+            for (AudioDeviceInfo device : devices) {
+                if (device.getId() == deviceId) {
+                    return audioManager.setCommunicationDevice(device);
+                }
+            }
+            return false;
+        }
+        private AudioDeviceInfo getCommunicationDevice() {
+            requireApi(31);
+            return audioManager.getCommunicationDevice();
+        }
+        private Object clearCommunicationDevice() {
+            requireApi(31);
+            audioManager.clearCommunicationDevice();
+            return null;
         }
         private Object setSpeakerphoneOn(boolean enabled) {
             audioManager.setSpeakerphoneOn(enabled);

--- a/android/src/main/java/com/ryanheise/audio_session/AndroidAudioManager.java
+++ b/android/src/main/java/com/ryanheise/audio_session/AndroidAudioManager.java
@@ -414,10 +414,14 @@ public class AndroidAudioManager implements MethodCallHandler {
             requireApi(23);
             return audioManager.isStreamMute(streamType);
         }
-        private List<AudioDeviceInfo> getAvailableCommunicationDevices() {
+        private List<Map<String, Object>> getAvailableCommunicationDevices() {
             requireApi(31);
             devices = audioManager.getAvailableCommunicationDevices();
-            return devices;
+            ArrayList<Map<String, Object>> result = new ArrayList<Map<String, Object>>();
+            for (AudioDeviceInfo device : devices) {
+                result.add(encodeAudioDevice(device));
+            }
+            return result;
         }
         private boolean setCommunicationDevice(Integer deviceId) {
             requireApi(31);
@@ -428,9 +432,9 @@ public class AndroidAudioManager implements MethodCallHandler {
             }
             return false;
         }
-        private AudioDeviceInfo getCommunicationDevice() {
+        private Map<String, Object> getCommunicationDevice() {
             requireApi(31);
-            return audioManager.getCommunicationDevice();
+            return encodeAudioDevice(audioManager.getCommunicationDevice());
         }
         private Object clearCommunicationDevice() {
             requireApi(31);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -169,42 +169,6 @@ class _MyAppState extends State<MyApp> {
                   },
                 ),
               ),
-
-              // All the following simply lets me exercise the new methods
-              // for testing. I'll delete it in another commit.
-              // It doesn't actually change the output of the player
-              // because this is not a voice chat / video chat app.
-              Expanded(
-                  child: FutureBuilder<List<AndroidAudioDeviceInfo>>(
-                      future: AndroidAudioManager()
-                          .getAvailableCommunicationDevices(),
-                      builder: (context, snapshot) {
-                        final devices = snapshot.data;
-                        if (devices == null) return SizedBox();
-                        return Column(
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            children: [
-                              Text('Communication Devices',
-                                  style: Theme.of(context).textTheme.headline6),
-                              for (var d in devices)
-                                TextButton(
-                                    child: Text('${d.id} ${d.type.name}'),
-                                    onPressed: () {
-                                      final mgr = AndroidAudioManager();
-                                      mgr
-                                          .setCommunicationDevice(d)
-                                          .then((value) {
-                                        print(
-                                            'set communication device returned $value');
-                                        mgr.getCommunicationDevice().then((d2) {
-                                          print(
-                                              'get communication device returned ${d2.id} ${d2.type.name}');
-                                          mgr.clearCommunicationDevice();
-                                        });
-                                      });
-                                    })
-                            ]);
-                      }))
             ],
           ),
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -169,6 +169,42 @@ class _MyAppState extends State<MyApp> {
                   },
                 ),
               ),
+
+              // All the following simply lets me exercise the new methods
+              // for testing. I'll delete it in another commit.
+              // It doesn't actually change the output of the player
+              // because this is not a voice chat / video chat app.
+              Expanded(
+                  child: FutureBuilder<List<AndroidAudioDeviceInfo>>(
+                      future: AndroidAudioManager()
+                          .getAvailableCommunicationDevices(),
+                      builder: (context, snapshot) {
+                        final devices = snapshot.data;
+                        if (devices == null) return SizedBox();
+                        return Column(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Text('Communication Devices',
+                                  style: Theme.of(context).textTheme.headline6),
+                              for (var d in devices)
+                                TextButton(
+                                    child: Text('${d.id} ${d.type.name}'),
+                                    onPressed: () {
+                                      final mgr = AndroidAudioManager();
+                                      mgr
+                                          .setCommunicationDevice(d)
+                                          .then((value) {
+                                        print(
+                                            'set communication device returned $value');
+                                        mgr.getCommunicationDevice().then((d2) {
+                                          print(
+                                              'get communication device returned ${d2.id} ${d2.type.name}');
+                                          mgr.clearCommunicationDevice();
+                                        });
+                                      });
+                                    })
+                            ]);
+                      }))
             ],
           ),
         ),

--- a/lib/src/android.dart
+++ b/lib/src/android.dart
@@ -173,8 +173,8 @@ class AndroidAudioManager {
 
   /// (UNTESTED) Requires API level 31
   Future<AndroidAudioDeviceInfo> getCommunicationDevice() async =>
-      (await _channel
-          .invokeMethod<AndroidAudioDeviceInfo>('getCommunicationDevice'))!;
+      _decodeAudioDevice(
+          await _channel.invokeMethod<dynamic>('getCommunicationDevice'));
 
   /// (UNTESTED) Requires API level 31
   Future<void> clearCommunicationDevice() async =>

--- a/lib/src/android.dart
+++ b/lib/src/android.dart
@@ -180,7 +180,7 @@ class AndroidAudioManager {
   Future<void> clearCommunicationDevice() async =>
       await _channel.invokeMethod('clearCommunicationDevice');
 
-  /// Deprecated by setCommunicationDevice in API level 31
+  /// (UNTESTED)
   Future<void> setSpeakerphoneOn(bool enabled) async {
     await _channel.invokeMethod<bool>('setSpeakerphoneOn', [enabled]);
   }

--- a/lib/src/android.dart
+++ b/lib/src/android.dart
@@ -160,7 +160,27 @@ class AndroidAudioManager {
         .invokeMethod<bool>('isStreamMute', [streamType.index]))!;
   }
 
-  /// (UNTESTED)
+  /// (UNTESTED) Requires API level 31
+  Future<List<AndroidAudioDeviceInfo>>
+      getAvailableCommunicationDevices() async =>
+          _decodeAudioDevices((await _channel.invokeMethod<List<dynamic>>(
+              'getAvailableCommunicationDevices')));
+
+  /// (UNTESTED) Requires API level 31
+  Future<bool> setCommunicationDevice(AndroidAudioDeviceInfo device) async =>
+      (await _channel
+          .invokeMethod<bool>('setCommunicationDevice', [device.id]))!;
+
+  /// (UNTESTED) Requires API level 31
+  Future<AndroidAudioDeviceInfo> getCommunicationDevice() async =>
+      (await _channel
+          .invokeMethod<AndroidAudioDeviceInfo>('getCommunicationDevice'))!;
+
+  /// (UNTESTED) Requires API level 31
+  Future<void> clearCommunicationDevice() async =>
+      await _channel.invokeMethod('clearCommunicationDevice');
+
+  /// Deprecated by setCommunicationDevice in API level 31
   Future<void> setSpeakerphoneOn(bool enabled) async {
     await _channel.invokeMethod<bool>('setSpeakerphoneOn', [enabled]);
   }


### PR DESCRIPTION
These require API level 31. See:
https://developer.android.com/reference/android/media/AudioManager#setCommunicationDevice(android.media.AudioDeviceInfo)

- getAvailableCommunicationDevices
- setCommunicationDevice
- getCommunicationDevice
- clearCommunicationDevice