### PR TITLE
Make sure outputs are not missed in getDevices

### DIFF
--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -307,10 +307,6 @@ class AudioSession {
     } else if (_avAudioSession != null) {
       final currentRoute = await _avAudioSession!.currentRoute;
       if (includeInputs) {
-        final darwinInputs = await _avAudioSession!.availableInputs;
-        devices.addAll(darwinInputs
-            .map((port) => _darwinPort2device(port, inputPorts: darwinInputs))
-            .toSet());
         devices.addAll(currentRoute.inputs.map((port) => _darwinPort2device(
               port,
               inputPorts: currentRoute.inputs,
@@ -323,6 +319,12 @@ class AudioSession {
               inputPorts: currentRoute.inputs,
               outputPorts: currentRoute.outputs,
             )));
+      }
+      if(includeInputs) {
+        final darwinInputs = await _avAudioSession!.availableInputs;
+        devices.addAll(darwinInputs
+            .map((port) => _darwinPort2device(port, inputPorts: darwinInputs))
+            .toSet());
       }
     }
     return devices;
@@ -351,8 +353,7 @@ class AudioSession {
         return AudioDeviceType.hdmi;
       case AVAudioSessionPort.headphones:
         return inputPorts
-                .map((desc) => desc.portType)
-                .contains(AVAudioSessionPort.headsetMic)
+                .any((desc) => desc.portType == AVAudioSessionPort.headsetMic)
             ? AudioDeviceType.wiredHeadset
             : AudioDeviceType.wiredHeadphones;
       case AVAudioSessionPort.lineOut:


### PR DESCRIPTION
Currently, `getDevices` returns headsets as being input only on iOS.

The device is currently added to the `devices` `Set` as an input-only. Then, since `AudioDevice`s compare equal if their ID is the same (which probably should not be changed willy nilly) the `add` is ignored when trying to add the same device as an output as well.