### PR TITLE
AndroidAudioFocusGainType.none

### DIFF
--- a/android/src/main/java/com/ryanheise/audio_session/AndroidAudioManager.java
+++ b/android/src/main/java/com/ryanheise/audio_session/AndroidAudioManager.java
@@ -322,7 +322,11 @@ public class AndroidAudioManager implements MethodCallHandler {
                 return true;
             }
             Map<?, ?> request = (Map<?, ?>)args.get(0);
-            AudioFocusRequestCompat.Builder builder = new AudioFocusRequestCompat.Builder((Integer)request.get("gainType"));
+            Integer gainType = (Integer)request.get("gainType");
+            if (gainType == 0) {
+                return true;
+            }
+            AudioFocusRequestCompat.Builder builder = new AudioFocusRequestCompat.Builder(gainType);
             builder.setOnAudioFocusChangeListener(focusChange -> {
                 if (focusChange == AudioManager.AUDIOFOCUS_LOSS) abandonAudioFocus();
                 invokeMethod("onAudioFocusChanged", focusChange);

--- a/lib/src/android.dart
+++ b/lib/src/android.dart
@@ -555,6 +555,7 @@ class AndroidAudioUsage {
 }
 
 class AndroidAudioFocusGainType {
+  static const none = AndroidAudioFocusGainType._(0);
   static const gain = AndroidAudioFocusGainType._(1);
   static const gainTransient = AndroidAudioFocusGainType._(2);
   static const gainTransientMayDuck = AndroidAudioFocusGainType._(3);
@@ -562,6 +563,7 @@ class AndroidAudioFocusGainType {
   /// Requires API level 19
   static const gainTransientExclusive = AndroidAudioFocusGainType._(4);
   static const values = {
+    0: none,
     1: gain,
     2: gainTransient,
     3: gainTransientMayDuck,


### PR DESCRIPTION
I'm not sure if this has been implemented correctly, but we needed a quick solution.

We have a use case where we don't want to gain focus at all. Thus, music from Spotify should continue playing at its current volume while the app's sound is played simultaneously.