### PR TITLE
fix incorrect argument types of `contains` method

### DIFF
--- a/lib/src/darwin.dart
+++ b/lib/src/darwin.dart
@@ -375,7 +375,7 @@ class AVAudioSessionCategoryOptions {
           AVAudioSessionCategoryOptions option) =>
       AVAudioSessionCategoryOptions(value & option.value);
 
-  bool contains(AVAudioSessionInterruptionOptions options) =>
+  bool contains(AVAudioSessionCategoryOptions options) =>
       options.value & value == options.value;
 
   @override
@@ -426,7 +426,7 @@ class AVAudioSessionSetActiveOptions {
           AVAudioSessionSetActiveOptions option) =>
       AVAudioSessionSetActiveOptions(value & option.value);
 
-  bool contains(AVAudioSessionInterruptionOptions options) =>
+  bool contains(AVAudioSessionSetActiveOptions options) =>
       options.value & value == options.value;
 
   @override


### PR DESCRIPTION
@ryanheise 

this fix #117 

I found one more similar bug in `AVAudioSessionCategoryOptions`'s `contains` method, so I fixed same way too.

I confirmed that I can build the example app after my fix is applied.
