### PR TITLE
IOS "InputGain" options

### DIFF
--- a/ios/Classes/DarwinAudioSession.m
+++ b/ios/Classes/DarwinAudioSession.m
@@ -86,7 +86,14 @@ static NSHashTable<DarwinAudioSession *> *sessions = nil;
         [self getInputLatency:args result:result];
     } else if ([@"getOutputLatency" isEqualToString:call.method]) {
         [self getOutputLatency:args result:result];
-    } else {
+    } else if ([@"getInputGain" isEqualToString:call.method]) {
+        [self getInputGain:args result:result];
+    } else if ([@"setInputGain" isEqualToString:call.method]) {
+        [self setInputGain:args result:result];
+    } else if ([@"isInputGainSettable" isEqualToString:call.method]){
+        [self getIsInputGainSettable:args result:result];
+    }
+    else {
         result(FlutterMethodNotImplemented);
     }
 }
@@ -474,6 +481,31 @@ static NSHashTable<DarwinAudioSession *> *sessions = nil;
 
 - (void)getOutputLatency:(NSArray *)args result:(FlutterResult)result {
     result(@((long long)([[AVAudioSession sharedInstance] outputLatency] * 1000000.0)));
+}
+
+- (void)getInputGain:(NSArray *)args result:(FlutterResult)result {
+    result(@([[AVAudioSession sharedInstance] inputGain]));
+}
+
+- (void)getIsInputGainSettable:(NSArray *)args result:(FlutterResult)result {
+    result(@([[AVAudioSession sharedInstance] isInputGainSettable]));
+}
+
+- (void)setInputGain:(NSArray *)args result:(FlutterResult)result {
+    
+     if (@available(iOS 6.0, *)) {
+         NSError *error = nil;
+         NSNumber *gainValue = (NSNumber *)args[0];
+         [[AVAudioSession sharedInstance] setInputGain:gainValue.floatValue error:&error];
+         
+         if (error) {
+             [self sendError:error result:result];
+         } else {
+             result(nil);
+         }
+     } else {
+         result(nil);
+     }
 }
 
 - (AVAudioSessionCategory)flutterToCategory:(NSNumber *)categoryIndex {

--- a/ios/Classes/DarwinAudioSession.m
+++ b/ios/Classes/DarwinAudioSession.m
@@ -484,11 +484,21 @@ static NSHashTable<DarwinAudioSession *> *sessions = nil;
 }
 
 - (void)getInputGain:(NSArray *)args result:(FlutterResult)result {
-    result(@([[AVAudioSession sharedInstance] inputGain]));
+    if (@available(iOS 6.0, *)) {
+        result(@([[AVAudioSession sharedInstance] inputGain]));
+    }
+    else{
+        result(nil);
+    }
 }
 
 - (void)getIsInputGainSettable:(NSArray *)args result:(FlutterResult)result {
-    result(@([[AVAudioSession sharedInstance] isInputGainSettable]));
+    if (@available(iOS 6.0, *)) {
+        result(@([[AVAudioSession sharedInstance] isInputGainSettable]));
+    }
+    else{
+        result(nil);
+    }
 }
 
 - (void)setInputGain:(NSArray *)args result:(FlutterResult)result {
@@ -496,13 +506,7 @@ static NSHashTable<DarwinAudioSession *> *sessions = nil;
      if (@available(iOS 6.0, *)) {
          NSError *error = nil;
          NSNumber *gainValue = (NSNumber *)args[0];
-         [[AVAudioSession sharedInstance] setInputGain:gainValue.floatValue error:&error];
-         
-         if (error) {
-             [self sendError:error result:result];
-         } else {
-             result(nil);
-         }
+         result(@([[AVAudioSession sharedInstance] setInputGain:gainValue.floatValue error:&error]));
      } else {
          result(nil);
      }

--- a/lib/src/darwin.dart
+++ b/lib/src/darwin.dart
@@ -281,16 +281,17 @@ class AVAudioSession {
 
   //Future<void> setPreferredOutputNumberOfChannels(int count) async {}
 
-  //Future<double> get inputGain async {
-  //  // TODO: key/value observing
-  //  return 0.5;
-  //}
+  Future<double?> getInputGain() async =>
+  (await _channel.invokeMethod<double>("getInputGain"));
 
-  //Future<bool> get inputGainSettable async {
-  //  return false;
-  //}
 
-  //Future<void> setInputGain(double gain) async {}
+  Future<bool?> get inputGainSettable async {
+   return await _channel.invokeMethod<bool>("isInputGainSettable");
+  }
+
+  Future<void> setInputGain(double gain) async {
+    _channel.invokeMethod("setInputGain", [gain]);
+  }
 
   //Future<double> get outputVolume async {
   //  return 1.0;

--- a/lib/src/darwin.dart
+++ b/lib/src/darwin.dart
@@ -289,8 +289,8 @@ class AVAudioSession {
    return await _channel.invokeMethod<bool>("isInputGainSettable");
   }
 
-  Future<void> setInputGain(double gain) async {
-    _channel.invokeMethod("setInputGain", [gain]);
+  Future<bool?> setInputGain(double gain) async {
+   return await _channel.invokeMethod("setInputGain", [gain]);
   }
 
   //Future<double> get outputVolume async {


### PR DESCRIPTION
Implemented ability to setup input gain for ios platform

`
if (_avAudioSession != null) {

       var gainValue = mute? 0.00001 : 1.0;
       var result = await _avAudioSession?.setInputGain(gainValue);

       _logger.log(LogLevel.debug,
           "AudioManager", "New InputGain state: ${gainValue.toString()} ${result?.toString()}");
}
`