### PR TITLE
Remove `-Werror` from JavaCompile task options

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 group 'com.ryanheise.audio_session'
 version '1.0'
-def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
+def args = ["-Xlint:deprecation","-Xlint:unchecked"]
 
 buildscript {
     repositories {


### PR DESCRIPTION
Hey, thank you for this plugin!

We are encountering a problem where this plugin is causing our Android Gradle build to fail since we're using the latest stable JDK (21). Please see pipeline run:

https://github.com/NIAEFEUP/uni/actions/runs/9971137557/job/27551546683

This PR removes `-Werror` which should resolve this issue. I think it's the right thing to do, because the plugin shouldn't be the one to decide whether to fail the whole build because of warnings.