### PR TITLE
Updated registerReciever signature for Android API 34 and above

### DIFF
--- a/android/src/main/java/com/ryanheise/audio_session/AndroidAudioManager.java
+++ b/android/src/main/java/com/ryanheise/audio_session/AndroidAudioManager.java
@@ -606,7 +606,11 @@ public class AndroidAudioManager implements MethodCallHandler {
                     }
                 }
             };
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU){
+                applicationContext.registerReceiver(noisyReceiver, new IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY), Context.RECEIVER_EXPORTED);
+            }else{
             applicationContext.registerReceiver(noisyReceiver, new IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY));
+            }
         }
 
         private void unregisterNoisyReceiver() {
@@ -628,7 +632,11 @@ public class AndroidAudioManager implements MethodCallHandler {
                     );
                 }
             };
-            applicationContext.registerReceiver(scoReceiver, new IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED));
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU){
+                applicationContext.registerReceiver(scoReceiver, new IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED), Context.RECEIVER_EXPORTED);
+            }else{
+                applicationContext.registerReceiver(scoReceiver, new IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED));
+            }
         }
 
         private void unregisterScoReceiver() {


### PR DESCRIPTION
Register Receiver signatures has been updating in Android API Level 34 and above.

This is causing application crash on Android 14 and Above.

https://medium.com/@malikfarooq4321/changes-to-broadcastreceiver-in-android-14-710cb0df2133