### PR TITLE
Fix channel "dispatchMediaKeyEvent" error

### DIFF
--- a/android/src/main/java/com/ryanheise/audio_session/AndroidAudioManager.java
+++ b/android/src/main/java/com/ryanheise/audio_session/AndroidAudioManager.java
@@ -362,11 +362,11 @@ public class AndroidAudioManager implements MethodCallHandler {
                     getLong(rawKeyEvent.get("downTime")),
                     getLong(rawKeyEvent.get("eventTime")),
                     (Integer)rawKeyEvent.get("action"),
-                    (Integer)rawKeyEvent.get("code"),
-                    (Integer)rawKeyEvent.get("repeat"),
+                    (Integer)rawKeyEvent.get("keyCode"),
+                    (Integer)rawKeyEvent.get("repeatCount"),
                     (Integer)rawKeyEvent.get("metaState"),
                     (Integer)rawKeyEvent.get("deviceId"),
-                    (Integer)rawKeyEvent.get("scancode"),
+                    (Integer)rawKeyEvent.get("scanCode"),
                     (Integer)rawKeyEvent.get("flags"),
                     (Integer)rawKeyEvent.get("source"));
             audioManager.dispatchMediaKeyEvent(keyEvent);


### PR DESCRIPTION
When I used the dispatchMediaKeyEvent method of AndroidAudioManager, an error occurred. Upon reviewing the source code, I found that the key value in the Map did not match, so I made a modification.

error key : code, repeat, scancode

**original code**
```
Map<String, dynamic> _toMap() => <String, dynamic>{
        'deviceId': deviceId,
        'source': source,
        'displayId': displayId,
        'metaState': metaState,
        'action': action,
        'keyCode': keyCode,
        'scanCode': scanCode,
        'repeatCount': repeatCount,
        'flags': flags,
        'downTime': downTime,
        'eventTime': eventTime,
      };
```
```
 private Object dispatchMediaKeyEvent(Map<?, ?> rawKeyEvent) {
            requireApi(19);
            KeyEvent keyEvent = new KeyEvent(
                    getLong(rawKeyEvent.get("downTime")),
                    getLong(rawKeyEvent.get("eventTime")),
                    (Integer)rawKeyEvent.get("action"),
                    (Integer)rawKeyEvent.get("code"),
                    (Integer)rawKeyEvent.get("repeat"),
                    (Integer)rawKeyEvent.get("metaState"),
                    (Integer)rawKeyEvent.get("deviceId"),
                    (Integer)rawKeyEvent.get("scancode"),
                    (Integer)rawKeyEvent.get("flags"),
                    (Integer)rawKeyEvent.get("source"));
            audioManager.dispatchMediaKeyEvent(keyEvent);
            return null;
        }
```
