### PR TITLE
feat: add try/catch to setActive because an exception could be encoun…

### DIFF
--- a/ios/Classes/DarwinAudioSession.m
+++ b/ios/Classes/DarwinAudioSession.m
@@ -201,10 +201,15 @@ static NSHashTable<DarwinAudioSession *> *sessions = nil;
         BOOL active = [args[0] boolValue];
         BOOL status;
 
-        if (args[1] != (id)[NSNull null]) {
-            status = [[AVAudioSession sharedInstance] setActive:active withOptions:[args[1] integerValue] error:&error];
-        } else {
-            status = [[AVAudioSession sharedInstance] setActive:active error:&error];
+        @try {
+            if (args[1] != (id)[NSNull null]) {
+                status = [[AVAudioSession sharedInstance] setActive:active withOptions:[args[1] integerValue] error:&error];
+            } else {
+                status = [[AVAudioSession sharedInstance] setActive:active error:&error];
+            }
+        } @catch (NSException *exception) {
+            error = [NSError errorWithDomain:@"com.ryanheise.audioSession" code:500 userInfo:@{NSLocalizedDescriptionKey: exception.reason}];
+            status = NO;
         }
 
         // Once the operation is done, switch back to the main thread to send the result


### PR DESCRIPTION
When I used the play method of just_audio, I met a crash exception as shown in the figure below. After testing, if an exception is thrown in the setActive of the audio_session, the mobile application will crash. Although I can not reproduce the problem in the log below. I still consider adding a reinforced logic in the setActive method to avoid the failure of code excution here. Or is there a more appropriate way to deal with it?

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/c46d5c1f-71c7-42d9-b813-a7ce8e68bd8c">
