### PR TITLE
Reinstate support for Android API <28

### DIFF
--- a/android/src/main/kotlin/com/ryanheise/audio_session/AndroidAudioManager.kt
+++ b/android/src/main/kotlin/com/ryanheise/audio_session/AndroidAudioManager.kt
@@ -605,7 +605,7 @@ private class AudioManagerSingleton(applicationContext: Context) {
                 mapOf(
                     "id" to device.id,
                     "productName" to device.getProductName(),
-                    "address" to address,
+                    "address" to address ?: "",
                     "isSource" to device.isSource,
                     "isSink" to device.isSink,
                     "sampleRates" to intArrayToList(device.sampleRates),
@@ -785,7 +785,7 @@ private class AudioManagerSingleton(applicationContext: Context) {
             return mapOf(
                 "id" to device.id,
                 "productName" to device.getProductName(),
-                "address" to address,
+                "address" to address ?: "",
                 "isSource" to device.isSource,
                 "isSink" to device.isSink,
                 "sampleRates" to device.sampleRates,

--- a/android/src/main/kotlin/com/ryanheise/audio_session/AndroidAudioManager.kt
+++ b/android/src/main/kotlin/com/ryanheise/audio_session/AndroidAudioManager.kt
@@ -785,7 +785,7 @@ private class AudioManagerSingleton(applicationContext: Context) {
             return mapOf(
                 "id" to device.id,
                 "productName" to device.getProductName(),
-                "address" to address!!,
+                "address" to address,
                 "isSource" to device.isSource,
                 "isSink" to device.isSink,
                 "sampleRates" to device.sampleRates,


### PR DESCRIPTION
Closes #158 .

The current version does not set `address` on Android versions below API 28, then proceeds to force unwrap it. This basically guarantees a crash on devices below API 28.

Here I'm removing the force unwrap to prevent the crash from happening. The implementation should be able to handle an address that's `null`