### PR TITLE
fix:AVAudioSession() method handler throwing when arguments where null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+* Fix AVAudioSession() method handler throwing when arguments where null (@snipd-mikel).
+
 ## 0.2.2
 
 * Run setCategory in a thread on iOS to avoid jank (@MinseokKang003).

--- a/lib/src/darwin.dart
+++ b/lib/src/darwin.dart
@@ -30,7 +30,9 @@ class AVAudioSession {
 
   AVAudioSession._() {
     _channel.setMethodCallHandler((MethodCall call) async {
-      final args = call.arguments as List<dynamic>;
+      final args = call.arguments == null
+          ? <dynamic>[]
+          : call.arguments as List<dynamic>;
       switch (call.method) {
         case 'onInterruptionEvent':
           _interruptionNotificationSubject


### PR DESCRIPTION
When AVAudioSession's method handler receives a call with null arguments, it silently throws and doesn't call the actual method handlers. This happens in `onMediaServicesWereLost` and `onMediaServicesWereReset`.