### PR TITLE
fix: Fixes toJson in AndroidAudioFocusRequest to match kotlin code

### DIFF
--- a/lib/src/android.dart
+++ b/lib/src/android.dart
@@ -598,7 +598,7 @@ class AndroidAudioFocusRequest {
 
   Map<String, dynamic> toJson() => {
         'gainType': gainType.index,
-        'audioAttribute': audioAttributes?.toJson(),
+        'audioAttributes': audioAttributes?.toJson(),
         'willPauseWhenDucked': willPauseWhenDucked,
       };
 }


### PR DESCRIPTION
This pull request makes a minor fix to the `AndroidAudioFocusRequest` class by correcting the key name in the `toJson` method to ensure consistency and proper serialization.

* Fixed a typo in the `toJson` method of `AndroidAudioFocusRequest`, changing `'audioAttribute'` to `'audioAttributes'` to match the class property name.