### PR TITLE
Fix Android LE Audio device type decoding

### DIFF
--- a/lib/src/android.dart
+++ b/lib/src/android.dart
@@ -762,40 +762,19 @@ enum AndroidAudioDeviceType {
   /// Android internal
   remoteSubmix(25),
 
-  /// Requires API level 31.
   bleHeadset(26),
-
-  /// Requires API level 31.
   bleSpeaker(27),
-
-  /// Requires API level 31.
   hdmiEarc(29),
-
-  /// Requires API level 33.
   bleBroadcast(30),
-
-  /// Requires API level 34.
   dockAnalog(31),
-
-  /// Requires API level 36.
   multichannelGroup(32),
-
-  /// Requires API level 37.
   bleHearingAid(33),
-
-  /// Requires API level 37.
   bleCentral(34),
-
-  /// Requires API level 37.
   bleCentralBroadcast(35),
-
-  /// Android internal (`@hide`). Kept out of platform-value order to ensure
-  /// decoding uses [value], not the Dart enum index.
   echoReference(28);
 
   const AndroidAudioDeviceType(this.value);
 
-  /// The corresponding `AudioDeviceInfo.TYPE_*` integer.
   final int value;
 
   static final Map<int, AndroidAudioDeviceType> _byValue = Map.unmodifiable({

--- a/lib/src/android.dart
+++ b/lib/src/android.dart
@@ -149,7 +149,7 @@ class AndroidAudioManager {
     return (await _channel.invokeMethod<double>('getStreamVolumeDb', [
       streamType.index,
       index,
-      deviceType.index,
+      deviceType.value,
     ]))!;
   }
 
@@ -435,7 +435,8 @@ class AndroidAudioManager {
                 (raw['channelIndexMasks'] as List<dynamic>).cast<int>(),
             channelCounts: (raw['channelCounts'] as List<dynamic>).cast<int>(),
             encodings: (raw['encodings'] as List<dynamic>).cast<int>(),
-            type: decodeEnum(AndroidAudioDeviceType.values, raw['type'] as int?,
+            type: decodeMapEnum(
+                AndroidAudioDeviceType._byValue, raw['type'] as int?,
                 defaultValue: AndroidAudioDeviceType.unknown),
           );
   }
@@ -732,34 +733,74 @@ enum AndroidRingerMode {
 }
 
 enum AndroidAudioDeviceType {
-  unknown,
-  builtInEarpiece,
-  builtInSpeaker,
-  wiredHeadset,
-  wiredHeadphones,
-  lineAnalog,
-  lineDigital,
-  bluetoothSco,
-  bluetoothA2dp,
-  hdmi,
-  hdmiArc,
-  usbDevice,
-  usbAccessory,
-  dock,
-  fm,
-  builtInMic,
-  fmTuner,
-  tvTuner,
-  telephony,
-  auxLine,
-  ip,
-  bus,
-  usbHeadset,
-  hearingAid,
-  builtInSpeakerSafe,
+  unknown(0),
+  builtInEarpiece(1),
+  builtInSpeaker(2),
+  wiredHeadset(3),
+  wiredHeadphones(4),
+  lineAnalog(5),
+  lineDigital(6),
+  bluetoothSco(7),
+  bluetoothA2dp(8),
+  hdmi(9),
+  hdmiArc(10),
+  usbDevice(11),
+  usbAccessory(12),
+  dock(13),
+  fm(14),
+  builtInMic(15),
+  fmTuner(16),
+  tvTuner(17),
+  telephony(18),
+  auxLine(19),
+  ip(20),
+  bus(21),
+  usbHeadset(22),
+  hearingAid(23),
+  builtInSpeakerSafe(24),
 
   /// Android internal
-  remoteSubmix,
+  remoteSubmix(25),
+
+  /// Requires API level 31.
+  bleHeadset(26),
+
+  /// Requires API level 31.
+  bleSpeaker(27),
+
+  /// Requires API level 31.
+  hdmiEarc(29),
+
+  /// Requires API level 33.
+  bleBroadcast(30),
+
+  /// Requires API level 34.
+  dockAnalog(31),
+
+  /// Requires API level 36.
+  multichannelGroup(32),
+
+  /// Requires API level 37.
+  bleHearingAid(33),
+
+  /// Requires API level 37.
+  bleCentral(34),
+
+  /// Requires API level 37.
+  bleCentralBroadcast(35),
+
+  /// Android internal (`@hide`). Kept out of platform-value order to ensure
+  /// decoding uses [value], not the Dart enum index.
+  echoReference(28);
+
+  const AndroidAudioDeviceType(this.value);
+
+  /// The corresponding `AudioDeviceInfo.TYPE_*` integer.
+  final int value;
+
+  static final Map<int, AndroidAudioDeviceType> _byValue = Map.unmodifiable({
+    for (final type in values) type.value: type,
+  });
 }
 
 class AndroidAudioCapturePolicy {

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -450,6 +450,21 @@ class AudioSession {
         return AudioDeviceType.builtInSpeakerSafe;
       case AndroidAudioDeviceType.remoteSubmix:
         return AudioDeviceType.remoteSubmix;
+      case AndroidAudioDeviceType.bleHeadset:
+      case AndroidAudioDeviceType.bleSpeaker:
+      case AndroidAudioDeviceType.bleBroadcast:
+      case AndroidAudioDeviceType.bleCentral:
+      case AndroidAudioDeviceType.bleCentralBroadcast:
+        return AudioDeviceType.bluetoothLe;
+      case AndroidAudioDeviceType.bleHearingAid:
+        return AudioDeviceType.hearingAid;
+      case AndroidAudioDeviceType.hdmiEarc:
+        return AudioDeviceType.hdmiArc;
+      case AndroidAudioDeviceType.dockAnalog:
+        return AudioDeviceType.dock;
+      case AndroidAudioDeviceType.multichannelGroup:
+      case AndroidAudioDeviceType.echoReference:
+        return AudioDeviceType.unknown;
     }
   }
 

--- a/test/android_audio_device_type_test.dart
+++ b/test/android_audio_device_type_test.dart
@@ -1,0 +1,90 @@
+import 'package:audio_session/src/android.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.ryanheise.android_audio_manager');
+  int? rawType;
+
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      if (call.method != 'getDevices') {
+        throw UnsupportedError('Unexpected method: ${call.method}');
+      }
+      return <Map<String, Object?>>[_audioDevice(rawType)];
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('decodes Android audio device types by raw platform value', () async {
+    const cases = <(int?, AndroidAudioDeviceType)>[
+      (26, AndroidAudioDeviceType.bleHeadset),
+      (27, AndroidAudioDeviceType.bleSpeaker),
+      (28, AndroidAudioDeviceType.echoReference),
+      (29, AndroidAudioDeviceType.hdmiEarc),
+      (30, AndroidAudioDeviceType.bleBroadcast),
+      (31, AndroidAudioDeviceType.dockAnalog),
+      (32, AndroidAudioDeviceType.multichannelGroup),
+      (33, AndroidAudioDeviceType.bleHearingAid),
+      (34, AndroidAudioDeviceType.bleCentral),
+      (35, AndroidAudioDeviceType.bleCentralBroadcast),
+      (-1, AndroidAudioDeviceType.unknown),
+      (36, AndroidAudioDeviceType.unknown),
+      (null, AndroidAudioDeviceType.unknown),
+    ];
+
+    for (final (platformValue, expectedType) in cases) {
+      rawType = platformValue;
+
+      final devices = await AndroidAudioManager().getDevices(
+        AndroidGetAudioDevicesFlags.outputs,
+      );
+
+      expect(
+        devices.single.type,
+        expectedType,
+        reason: 'raw platform value $platformValue',
+      );
+    }
+  });
+
+  test('sends the raw device type value when querying stream volume', () async {
+    MethodCall? platformCall;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      platformCall = call;
+      return 0.0;
+    });
+
+    await AndroidAudioManager().getStreamVolumeDb(
+      AndroidStreamType.music,
+      7,
+      AndroidAudioDeviceType.hdmiEarc,
+    );
+
+    expect(platformCall?.method, 'getStreamVolumeDb');
+    expect(platformCall?.arguments,
+        <Object>[AndroidStreamType.music.index, 7, 29]);
+  });
+}
+
+Map<String, Object?> _audioDevice(int? type) => <String, Object?>{
+      'id': 1,
+      'productName': 'Test audio device',
+      'address': '',
+      'isSource': false,
+      'isSink': true,
+      'sampleRates': <int>[48000],
+      'channelMasks': <int>[],
+      'channelIndexMasks': <int>[],
+      'channelCounts': <int>[2],
+      'encodings': <int>[],
+      'type': type,
+    };


### PR DESCRIPTION
## Summary

- preserve Android audio device type integers 26 through 35, including hidden value 28
- decode device types through explicit raw values instead of Dart enum positions
- preserve raw values when calling `getStreamVolumeDb`
- map the new Android types conservatively into existing cross-platform device types
- add regression coverage for decoding, invalid values, and outbound serialization

## Verification that the types are missing

Verified against both released `audio_session` 0.2.4 and upstream `master` before this change:

- [`AndroidAudioDeviceType` ends at `remoteSubmix`, index 25](https://github.com/ryanheise/audio_session/blob/v0.2.4/lib/src/android.dart#L734-L763).
- [Device decoding uses `AndroidAudioDeviceType.values[rawType]`](https://github.com/ryanheise/audio_session/blob/v0.2.4/lib/src/android.dart#L423-L440), so every value above 25 falls back to `unknown`.
- Searches for the Android members represented by values 26 through 35 returned no matches in either version.
- [The Kotlin plugin already forwards `device.type` unchanged](https://github.com/ryanheise/audio_session/blob/v0.2.4/android/src/main/kotlin/com/ryanheise/audio_session/AndroidAudioManager.kt), so the loss occurs in Dart.

## Android sources

- [Android 14 source](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android14-release/media/java/android/media/AudioDeviceInfo.java) defines values 26 through 31, including hidden `TYPE_ECHO_REFERENCE` at 28.
- [Android 15 source](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android15-release/media/java/android/media/AudioDeviceInfo.java) retains values 26 through 31.
- [Android 16 source](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android16-release/media/java/android/media/AudioDeviceInfo.java) adds `TYPE_MULTICHANNEL_GROUP` at 32.
- [The current Android API reference](https://developer.android.com/reference/android/media/AudioDeviceInfo) documents API 37 values 33 through 35: `TYPE_BLE_HEARING_AID`, `TYPE_BLE_CENTRAL`, and `TYPE_BLE_CENTRAL_BROADCAST`.

## Root cause

The platform integer was treated as a Dart enum index. Explicit raw values prevent hidden or future Android constants from shifting later meanings.

## Validation

- `flutter test`: 2 tests pass. The tests pass complete MethodChannel device maps through the real decoder for values 26 through 35, `-1`, `36`, and `null`.
- The outbound `getStreamVolumeDb` test verifies Android value 29 is sent even though the Dart enum index differs.
- `flutter analyze`: no issues.
- Formatter check: no changes.

Physical LE Audio hardware was not available for verification. The attached Android 14 device reports `mLeAudio: null` and an active classic A2DP device, so it cannot reproduce the LE path. The regression tests verify the Dart channel boundary using the exact raw Android integers.

## Scope

This changes no Kotlin code, Android permission, or manifest entry. Active-route detection and Darwin port support remain separate concerns.

Fixes #185