### PR TITLE
Fix @UiThread crash when audio devices change on Android TV (fixes #188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5
+
+* Fix crash "Methods marked with @UiThread must be executed on the main thread" on Android TV devices by dispatching method channel invocations on the main looper.
+
 ## 0.2.4
 
 * Support AGP 9.

--- a/android/src/main/kotlin/com/ryanheise/audio_session/AndroidAudioManager.kt
+++ b/android/src/main/kotlin/com/ryanheise/audio_session/AndroidAudioManager.kt
@@ -715,9 +715,16 @@ private class AudioManagerSingleton(applicationContext: Context) {
     }
 
     fun invokeMethod(method: String, vararg args: Any?) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            invokeMethodOnMain(method, args)
+        } else {
+            handler.post { invokeMethodOnMain(method, args) }
+        }
+    }
+
+    private fun invokeMethodOnMain(method: String, args: Array<out Any?>) {
         for (instance in instances) {
-            val list = args.toMutableList()
-            instance.channel!!.invokeMethod(method, list)
+            instance.channel!!.invokeMethod(method, args.toMutableList())
         }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_session
 description: Sets the iOS audio session category and Android audio attributes for your app, and manages your app's audio focus, mixing and ducking behaviour.
-version: 0.2.4
+version: 0.2.5
 homepage: https://github.com/ryanheise/audio_session
 topics:
   - audio


### PR DESCRIPTION
# PR Description — Fix @UiThread crash on Android TV HDMI devices

**Title:**
```
Fix @UiThread crash when audio devices change on Android TV (fixes #188)
```

**Body** (paste into the PR description):

```
Fixes #188

## Problem

On some Android TV boxes, `AudioManager$AudioMonitorHdmiThread` invokes
`AudioDeviceCallback.onAudioDevicesAdded/onAudioDevicesRemoved` on a background
thread, ignoring the main-looper `Handler` passed to
`AudioManager.registerAudioDeviceCallback()`. The callback then calls
`MethodChannel.invokeMethod()` (annotated `@UiThread`) from that thread, causing
a fatal crash:

    java.lang.RuntimeException: Methods marked with @UiThread must be executed on the main thread.

Affected devices include Skyworth TV boxes (Android 10), Inspur set-top boxes
(Android 11), and low-end Fire TV devices. Phones are unaffected because the
HDMI audio monitor thread does not exist there.

First report: https://github.com/ryanheise/just_audio/issues/1484

## Fix

Guard `AudioManagerSingleton.invokeMethod()` so all MethodChannel invocations
are dispatched on the main looper. This is a single-point fix covering all
callback-originated events (audio devices added/removed, focus change, becoming
noisy, SCO audio state), rather than patching each callback.

If already on the main thread, dispatch directly to avoid an unnecessary hop.

## Verification

- `flutter analyze` passes
- `flutter test` passes (example app)
- Runtime-tested logic: on-main-thread path identical to previous behavior;
  off-main-thread path is now marshalled to the main thread